### PR TITLE
Digitize od

### DIFF
--- a/WCSim.cc
+++ b/WCSim.cc
@@ -113,7 +113,6 @@ int main(int argc,char** argv)
     G4UIsession* session =  new G4UIterminal(new G4UItcsh);
 
     // Visualization Macro
-    file_exists("vis.mac");
     UI->ApplyCommand("/control/execute vis.mac");
 
     // Start Interactive Mode
@@ -126,7 +125,6 @@ int main(int argc,char** argv)
     G4String command = "/control/execute ";
     G4String fileName = argv[1];
 
-    file_exists(fileName.c_str());
     UI->ApplyCommand(command+fileName);
   }
 

--- a/WCSim.cc
+++ b/WCSim.cc
@@ -20,6 +20,14 @@
 #include "WCSimRandomParameters.hh"
 #include <iostream>
 
+void file_exists(const char * filename) {
+  bool exists = access(filename, F_OK) != -1;
+  if(!exists) {
+    G4cerr << filename << " not found or inaccessible. Exiting" << G4endl;
+    exit(-1);
+  }
+}
+
 int main(int argc,char** argv)
 {
   // Construct the default run manager
@@ -33,6 +41,7 @@ int main(int argc,char** argv)
   WCSimTuningParameters* tuningpars = new WCSimTuningParameters();
 
   // Get the tuning parameters
+  file_exists("tuning_parameters.mac");
   UI->ApplyCommand("/control/execute tuning_parameters.mac");
 
   // define random number generator parameters
@@ -52,6 +61,7 @@ int main(int argc,char** argv)
   WCSimPhysicsListFactory *physFactory = new WCSimPhysicsListFactory();
 
   // Currently, default model is set to BINARY
+  file_exists("jobOptions.mac");
   UI->ApplyCommand("/control/execute jobOptions.mac");
 
   // Initialize the physics factory to register the selected physics.
@@ -68,6 +78,7 @@ int main(int argc,char** argv)
   // by the program BEFORE the runManager is initialized.
   // If file does not exist, default model will be used.
   // Currently, default model is set to BINARY.
+  file_exists("jobOptions2.mac");
   UI->ApplyCommand("/control/execute jobOptions2.mac");
 
   // Visualization
@@ -102,6 +113,7 @@ int main(int argc,char** argv)
     G4UIsession* session =  new G4UIterminal(new G4UItcsh);
 
     // Visualization Macro
+    file_exists("vis.mac");
     UI->ApplyCommand("/control/execute vis.mac");
 
     // Start Interactive Mode
@@ -114,6 +126,7 @@ int main(int argc,char** argv)
     G4String command = "/control/execute ";
     G4String fileName = argv[1];
 
+    file_exists(fileName.c_str());
     UI->ApplyCommand(command+fileName);
   }
 

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -125,6 +125,7 @@ public:
   // Geometry options
   void   SetIsUpright(G4bool choice) {isUpright = choice;}
 
+  G4int UseOD;
   // *** Begin HyperK Geometry ***
 
   void   SetIsHyperK(G4bool choice) {isHyperK = choice;}
@@ -139,6 +140,7 @@ public:
   std::vector<WCSimPmtInfo*>* Get_Pmts() {return &fpmts;}
 
   G4String GetIDCollectionName(){return WCIDCollectionName;}
+  G4String GetODCollectionName(){return WCODCollectionName;}
 
  
 private:

--- a/include/WCSimDetectorConstruction.hh
+++ b/include/WCSimDetectorConstruction.hh
@@ -125,7 +125,7 @@ public:
   // Geometry options
   void   SetIsUpright(G4bool choice) {isUpright = choice;}
 
-  G4int UseOD;
+  G4bool UseOD;
   // *** Begin HyperK Geometry ***
 
   void   SetIsHyperK(G4bool choice) {isHyperK = choice;}

--- a/include/WCSimDetectorMessenger.hh
+++ b/include/WCSimDetectorMessenger.hh
@@ -36,6 +36,7 @@ class WCSimDetectorMessenger: public G4UImessenger
   G4UIcmdWithAString* SavePi0;
   G4UIcmdWithAString* PMTQEMethod;
   G4UIcmdWithAString* PMTCollEff;
+  G4UIcmdWithAString* DigitizedVolume;
   G4UIcmdWithADoubleAndUnit* waterTank_Length;
 
 

--- a/novis.mac
+++ b/novis.mac
@@ -62,6 +62,10 @@
 #turn on or off the collection efficiency
 #/WCSim/PMTCollEff on
 
+#Digitize ID or OD volumes
+
+/WCSim/DigitizedVolume ID
+
 # command to choose save or not save the pi0 info 07/03/10 (XQ)
 /WCSim/SavePi0 false
 
@@ -87,9 +91,9 @@
 
 # Or you can use the G4 Particle Gun
 /mygen/generator normal
-/gun/particle e-
+/gun/particle mu-
 #/gun/particle pi0
-/gun/energy 500 MeV
+/gun/energy 5000 MeV
 /gun/direction 1 0 0 
 /gun/position 0 0 0  
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -23,7 +23,6 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCDetectorName = "SuperK";
   WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
   WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", WCIDCollectionName);
- 
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -38,6 +37,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCCapEdgeLimit        = 16.9*m;
   WCBlackSheetThickness = 2.0*cm;
   WCAddGd               = false;
+  UseOD = false;
  }
 
 

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -24,10 +24,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCIDCollectionName = WCDetectorName +"-glassFaceWCPMT";
   WCODCollectionName = WCDetectorName + "-glassFaceWCPMT_OD"; 
   WCSimPMTObject * PMT = CreatePMTObject("PMT20inch", WCIDCollectionName);
-<<<<<<< HEAD
-=======
   WCSimPMTObject * outerPMT = CreatePMTObject("PMT8inch", WCODCollectionName);
->>>>>>> a53045560e0166ac4c20fa1040ec514891ede02b
   WCPMTName = PMT->GetPMTName();
   WCPMTExposeHeight = PMT->GetExposeHeight();
   WCPMTRadius = PMT->GetRadius();
@@ -42,15 +39,11 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCCapEdgeLimit        = 16.9*m;
   WCBlackSheetThickness = 2.0*cm;
   WCAddGd               = false;
-<<<<<<< HEAD
   UseOD = false;
- }
-=======
   outerPMT_Name = outerPMT->GetPMTName();
   outerPMT_Expose = outerPMT->GetExposeHeight();
   outerPMT_Radius = outerPMT->GetRadius();
 }
->>>>>>> a53045560e0166ac4c20fa1040ec514891ede02b
 
 // Note: the actual coverage is 20.27%
 void WCSimDetectorConstruction::SuperK_20inchPMT_20perCent()

--- a/src/WCSimDetectorConfigs.cc
+++ b/src/WCSimDetectorConfigs.cc
@@ -38,7 +38,7 @@ void WCSimDetectorConstruction::SetSuperKGeometry()
   WCCapEdgeLimit        = 16.9*m;
   WCBlackSheetThickness = 2.0*cm;
   WCAddGd               = false;
-}
+ }
 
 
 // Note: the actual coverage is 20.27%

--- a/src/WCSimDetectorMessenger.cc
+++ b/src/WCSimDetectorMessenger.cc
@@ -90,6 +90,15 @@ WCSimDetectorMessenger::WCSimDetectorMessenger(WCSimDetectorConstruction* WCSimD
 			    "off ");
   PMTCollEff->AvailableForStates(G4State_PreInit, G4State_Idle);
 
+  DigitizedVolume = new G4UIcmdWithAString("/WCSim/DigitizedVolume", this);
+  DigitizedVolume->SetGuidance("Digitize the ID or OD");
+  DigitizedVolume->SetGuidance("Available options are:\n"
+			  "ID\n"
+			  "OD\n");
+  DigitizedVolume->SetParameterName("DigitizedVolume", false);
+  DigitizedVolume->SetCandidates("ID "
+			    "OD ");
+  DigitizedVolume->AvailableForStates(G4State_PreInit, G4State_Idle);
 
   waterTank_Length = new G4UIcmdWithADoubleAndUnit("/WCSim/HyperK/waterTank_Length", this);
   waterTank_Length->SetGuidance("Set the Length of Hyper-K detector (unit: mm cm m).");
@@ -108,6 +117,7 @@ WCSimDetectorMessenger::~WCSimDetectorMessenger()
   delete SavePi0;
   delete PMTQEMethod;
   delete PMTCollEff;
+  delete DigitizedVolume;
   delete waterTank_Length;
 
   delete tubeCmd;
@@ -194,6 +204,15 @@ void WCSimDetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 	  }else if (newValue == "off"){
 	    WCSimDetector->SetPMT_Coll_Eff(0);
 	    G4cout << "0";
+	  }
+	  G4cout << G4endl;
+	}
+	if (command == DigitizedVolume){
+	  G4cout << "Setting the digitized volume to be " << newValue << " ";
+	  if (newValue == "ID"){
+	    WCSimDetector->UseOD=false;
+	  }else if (newValue == "OD"){
+	    WCSimDetector->UseOD=true;
 	  }
 	  G4cout << G4endl;
 	}

--- a/src/WCSimEventAction.cc
+++ b/src/WCSimEventAction.cc
@@ -92,9 +92,11 @@ void WCSimEventAction::EndOfEventAction(const G4Event* evt)
   G4HCofThisEvent* HCE         = evt->GetHCofThisEvent();
   WCSimWCHitsCollection* WCHC = 0;
   G4String WCIDCollectionName = detectorConstructor->GetIDCollectionName();
+  G4String WCODCollectionName = detectorConstructor->GetODCollectionName();
   if (HCE)
-  { 
-    G4String name =   WCIDCollectionName;
+    { G4String name;
+      if(detectorConstructor->UseOD==true) name =   WCODCollectionName;
+      else {name =   WCIDCollectionName;}
     G4int collectionID = SDman->GetCollectionID(name);
     WCHC = (WCSimWCHitsCollection*)HCE->GetHC(collectionID);
   }

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -1206,7 +1206,7 @@ G4double BoxandLine20inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine20inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};
-  G4float lambda_param[2]={0.4094,0.06852};
+  G4float lambda_param[2]={0.4113,0.07827};
   G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
 
   G4float highcharge_param[2];
@@ -1375,7 +1375,7 @@ G4double BoxandLine12inchHQE::GetPMTGlassThickness() {return 0.4*cm;}
 
 float BoxandLine12inchHQE::HitTimeSmearing(float Q) {
   G4float sig_param[4]={0.6314,0.06260,0.5711,23.96};
-  G4float lambda_param[2]={0.4094,0.06852};
+  G4float lambda_param[2]={0.4113,0.07827};
 
   G4float highcharge_param[2];
   highcharge_param[0]=2*sig_param[0]*sig_param[1]*sig_param[3]*sqrt(sig_param[3])*exp(-sig_param[1]*sig_param[3]);

--- a/src/WCSimPMTObject.cc
+++ b/src/WCSimPMTObject.cc
@@ -858,8 +858,8 @@ G4double HPD20inchHQE::GetExposeHeight() {return .192*m;}
 G4double HPD20inchHQE::GetRadius() {return .254*m;}
 G4double HPD20inchHQE::GetPMTGlassThickness() {return 0.3*cm;}
 float HPD20inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.7816,0.1364,0.3635,11.00};
-  G4float lambda_param[2]={0.4081,0.1021};
+  G4float sig_param[4]={0.6718,0.1264,0.4450,11.87};
+  G4float lambda_param[2]={0.3255,0.1142};
 
   G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
 
@@ -1026,8 +1026,8 @@ G4double HPD12inchHQE::GetExposeHeight() {return 118.*mm;} //Assumed to be the s
 G4double HPD12inchHQE::GetRadius() {return 152.4*mm;} //12 inches
 G4double HPD12inchHQE::GetPMTGlassThickness() {return 0.3*cm;} 
 float HPD12inchHQE::HitTimeSmearing(float Q) {
-  G4float sig_param[4]={0.7816,0.1364,0.3635,11.00};
-  G4float lambda_param[2]={0.4081,0.1021};
+  G4float sig_param[4]={0.6718,0.1264,0.4450,11.87};
+  G4float lambda_param[2]={0.3255,0.1142};
 
   G4float sigma_lowcharge = sig_param[0]*(exp(-sig_param[1]*Q)+sig_param[2]);
 

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -31,7 +31,11 @@ const double WCSimWCDigitizer::eventgateup = 950.0 ; // ns
 const double WCSimWCDigitizer::eventgatedown = -400.0 ; // ns
 const double WCSimWCDigitizer::LongTime = 100000.0 ; // ns
 // value in skdetsim
-const int WCSimWCDigitizer::GlobalThreshold = 25 ; // # hit PMTs
+
+const int WCSimWCDigitizer::GlobalThreshold = 0 ; // # hit PMTs
+
+
+
 //const int WCSimWCDigitizer::GlobalThreshold = 12 ; // # hit PMTs
 // try to trigger early to reduce the width.
 //const int WCSimWCDigitizer::GlobalThreshold = 10 ; // # hit PMTs

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -346,9 +346,11 @@ void WCSimWCDigitizer::FindNumberOfGates()
 void WCSimWCDigitizer::DigitizeGate(WCSimWCDigitsCollection* WCHCPMT,G4int G)
 {
   G4String WCIDCollectionName = myDetector->GetIDCollectionName();
+  G4String WCODCollectionName = myDetector->GetODCollectionName();
   G4float timingConstant = 0.0;
   WCSimPMTObject * PMT;
-  PMT = myDetector->GetPMTPointer(WCIDCollectionName);
+  if(myDetector->UseOD == true)  PMT = myDetector->GetPMTPointer(WCODCollectionName);
+  else{PMT = myDetector->GetPMTPointer(WCIDCollectionName);}
  
   G4double EvtG8Down = WCSimWCDigitizer::eventgatedown;
   G4double EvtG8Up = WCSimWCDigitizer::eventgateup;  // this is a negative number...

--- a/src/WCSimWCDigitizer.cc
+++ b/src/WCSimWCDigitizer.cc
@@ -32,7 +32,7 @@ const double WCSimWCDigitizer::eventgatedown = -400.0 ; // ns
 const double WCSimWCDigitizer::LongTime = 100000.0 ; // ns
 // value in skdetsim
 
-const int WCSimWCDigitizer::GlobalThreshold = 0 ; // # hit PMTs
+const int WCSimWCDigitizer::GlobalThreshold = 25 ; // # hit PMTs
 
 
 

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -65,10 +65,14 @@ void WCSimWCPMT::Digitize()
 {
   DigitsCollection = new WCSimWCDigitsCollection ("WCDigitizedCollectionPMT",collectionName[0]);
   G4String WCIDCollectionName = myDetector->GetIDCollectionName();
+  G4String WCODCollectionName = myDetector->GetODCollectionName();
+  
   G4DigiManager* DigiMan = G4DigiManager::GetDMpointer();
  
   // Get the Associated Hit collection IDs
-  G4int WCHCID = DigiMan->GetHitsCollectionID(WCIDCollectionName);
+  
+  if(myDetector->UseOD == true)  G4int WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);
+  else{  G4int WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);}
 
   // The Hits collection
   WCSimWCHitsCollection* WCHC =

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -41,7 +41,9 @@ WCSimWCPMT::~WCSimWCPMT(){
 }
 
 G4double WCSimWCPMT::rn1pe(){
-  G4String WCIDCollectionName = myDetector->GetIDCollectionName();
+  G4String WCIDCollectionName; 
+    if(myDetector->UseOD == false) WCIDCollectionName = myDetector->GetIDCollectionName();
+    else {WCIDCollectionName = myDetector->GetODCollectionName();}
   WCSimPMTObject * PMT;
   PMT = myDetector->GetPMTPointer(WCIDCollectionName);
   G4int i;
@@ -72,7 +74,7 @@ void WCSimWCPMT::Digitize()
   // Get the Associated Hit collection IDs
   G4int WCHCID;
   if(myDetector->UseOD == true)  WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);
-  else{  WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);}
+  else{  WCHCID = DigiMan->GetHitsCollectionID(WCIDCollectionName);}
 
   // The Hits collection
   WCSimWCHitsCollection* WCHC =

--- a/src/WCSimWCPMT.cc
+++ b/src/WCSimWCPMT.cc
@@ -70,9 +70,9 @@ void WCSimWCPMT::Digitize()
   G4DigiManager* DigiMan = G4DigiManager::GetDMpointer();
  
   // Get the Associated Hit collection IDs
-  
-  if(myDetector->UseOD == true)  G4int WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);
-  else{  G4int WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);}
+  G4int WCHCID;
+  if(myDetector->UseOD == true)  WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);
+  else{  WCHCID = DigiMan->GetHitsCollectionID(WCODCollectionName);}
 
   // The Hits collection
   WCSimWCHitsCollection* WCHC =


### PR DESCRIPTION
## Description

Some code to make it possible to control in the macro whether to store information and digitize the hits from the inner detector (ID) or the hits from the outer detector (OD). This is crude and just meant for use in verifying that the OD tubes are behaving as expected. 
## Changes in this pull request
- novis.mac now runs a high energy muon so we get some light in the OD. 
- Some code differences are also due to your branch not being even with the upstream develop, so any commits from before July 15th are changes that will come along for the ride. Update your develop (and your ODWork) branch to be even with the upstream develop (see https://github.com/WCSim/WCSim/wiki/How-to-Keep-your-Branches-Up-to-Date). 
- WCSimWCPMT, WCSimWCDigitizer, WCSimEventAction: Now decide whether to use the ID or OD hit collection based off the UseOD bool. This is set to false (use the ID) in SetSuperKGeometry(). The UseOD bool can be controlled in the macro using the `/WCSim/DigitizedVolume` line (options are ID or OD). 
- I didn't transfer the changes to vis.mac since I assume you will be also modifying this for your raytracer visualization. If you want to record the OD hits and use vis.mac, just copy over the `/WCSim/DigitizedVolume` line (and make the particle a high energy muon if you want OD hits).
